### PR TITLE
(feat) User trips render in view Trips

### DIFF
--- a/database-mongo/trips.js
+++ b/database-mongo/trips.js
@@ -5,12 +5,20 @@ const tripSchema = mongoose.Schema({
   food: Array,
   attractions: Array,
   lodging: Array,
-  destination: String
+  destination: String,
+  name: String,
+  description: String
 });
 
-tripSchema.statics.getTrips = function(tripArray) {
+tripSchema.statics.getTrips = function(user, callback) {
   console.log('we made it to the trips schema!');
-  return this.find({"id": {"$in" : tripArray}})
+  this.find({
+    "id": {"$in" : user.trips}
+  })
+  .then( (trips) => {
+    user.trips = trips;
+    callback(user);
+  })
 };
 
 const Trip = mongoose.model('Trip', tripSchema);

--- a/react-client/src/components/CreateView/chooser/saveBox.jsx
+++ b/react-client/src/components/CreateView/chooser/saveBox.jsx
@@ -43,6 +43,7 @@ class SaveBox extends React.Component {
       contentType: 'application/json',
       success: (data) => {
         console.log('the POST request went through! ', data);
+        this.props.changePage('VIEW');
       },
       error: (err) => {
         console.log('err', err);
@@ -84,6 +85,7 @@ class SaveBox extends React.Component {
         modal={false}
         open={this.props.open}
         onRequestClose={this.props.toggle}
+        title='Save this trip:'
         actionsContainerStyle={{
           display: 'flex',
           justifyContent: 'center',

--- a/react-client/src/components/CreateView/chooser/saveBox.jsx
+++ b/react-client/src/components/CreateView/chooser/saveBox.jsx
@@ -33,7 +33,9 @@ class SaveBox extends React.Component {
       attractions: this.props.trip.attractions,
       lodging: this.props.trip.hotels,
       destination: this.props.destination,
-      facebookId: this.props.user.id
+      facebookId: this.props.user.id,
+      name: this.state.name,
+      description: this.state.description
     };
     console.log(postData);
     $.ajax({
@@ -42,8 +44,8 @@ class SaveBox extends React.Component {
       data: JSON.stringify(postData),
       contentType: 'application/json',
       success: (data) => {
-        console.log('the POST request went through! ', data);
-        this.props.changePage('VIEW');
+        console.log('data returned from saved trip: ', data);
+        this.props.createToView(data.trips, 'LIST');
       },
       error: (err) => {
         console.log('err', err);

--- a/react-client/src/components/CreateView/index.jsx
+++ b/react-client/src/components/CreateView/index.jsx
@@ -200,7 +200,7 @@ class CreateView extends React.Component {
       dialogBox = (
         <SaveBox
           destination={this.state.searchText}
-          changePage={this.props.changePage}
+          createToView={this.props.createToView}
           open={this.state.saveBox}
           toggle={this.saveBox}
           trip={this.state.trip}

--- a/react-client/src/components/ViewTrips/TripsView/index.jsx
+++ b/react-client/src/components/ViewTrips/TripsView/index.jsx
@@ -9,8 +9,6 @@ class TripsView extends React.Component {
 
   render() {
 
-    console.log('User on TripsView: ', this.props.user);
-
     return (
       <div 
         id="selection-component" 

--- a/react-client/src/components/ViewTrips/TripsView/tripslist/Images.jsx
+++ b/react-client/src/components/ViewTrips/TripsView/tripslist/Images.jsx
@@ -2,58 +2,24 @@ import React from 'react';
 
 import {GridList, GridTile} from 'material-ui/GridList';
 
+import exampleData from './exampleData.js';
+
 class Images extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  buildGrid(object) {
+    var array = [];
+    for (let category in object) {
+      for (var i = 0; i < object[category].length - 1; i++) {
+        array.push(object[category][i]);
+      }
+    }
+    return array;
+  }
 
   render() {
-
-    const tilesData = [
-      {
-        img: 'http://i2.cdn.cnn.com/cnnnext/dam/assets/161201115958-68-year-in-pictures-2016-restricted-super-169.jpg',
-        title: 'Breakfast',
-        author: 'jill111',
-      },
-      {
-        img: 'http://i2.cdn.cnn.com/cnnnext/dam/assets/161201161116-83-year-in-pictures-2016-restricted-super-169.jpg',
-        title: 'Tasty burger',
-        author: 'pashminu',
-      },
-      {
-        img: 'https://i.ytimg.com/vi/qh7LLydY8eo/maxresdefault.jpg',
-        title: 'Camera',
-        author: 'Danson67',
-      },
-      {
-        img: 'http://i2.cdn.cnn.com/cnnnext/dam/assets/161201115958-68-year-in-pictures-2016-restricted-super-169.jpg',
-        title: 'Breakfast',
-        author: 'jill111',
-      },
-      {
-        img: 'http://i2.cdn.cnn.com/cnnnext/dam/assets/161201161116-83-year-in-pictures-2016-restricted-super-169.jpg',
-        title: 'Tasty burger',
-        author: 'pashminu',
-      },
-      {
-        img: 'https://i.ytimg.com/vi/qh7LLydY8eo/maxresdefault.jpg',
-        title: 'Camera',
-        author: 'Danson67',
-      },
-      {
-        img: 'http://i2.cdn.cnn.com/cnnnext/dam/assets/161201115958-68-year-in-pictures-2016-restricted-super-169.jpg',
-        title: 'Breakfast',
-        author: 'jill111',
-      },
-      {
-        img: 'http://i2.cdn.cnn.com/cnnnext/dam/assets/161201161116-83-year-in-pictures-2016-restricted-super-169.jpg',
-        title: 'Tasty burger',
-        author: 'pashminu',
-      },
-      {
-        img: 'https://i.ytimg.com/vi/qh7LLydY8eo/maxresdefault.jpg',
-        title: 'Camera',
-        author: 'Danson67',
-      },
-    ];
-
 
     return (
 
@@ -78,9 +44,12 @@ class Images extends React.Component {
         >
           {
             // mock data
-            tilesData.map( (tile, i) => (
+            this.buildGrid(exampleData).map( (tile, i) => (
               <GridTile
                 key={i}
+                style={{
+                  height: '95%'
+                }}
                 title={tile.title}
                 subtitle={tile.author}
                 titleBackground="linear-gradient(to top, rgba(0,0,0,0.7) 0%,rgba(0,0,0,0.3) 70%,rgba(0,0,0,0) 100%)"

--- a/react-client/src/components/ViewTrips/TripsView/tripslist/Images.jsx
+++ b/react-client/src/components/ViewTrips/TripsView/tripslist/Images.jsx
@@ -12,8 +12,10 @@ class Images extends React.Component {
   buildGrid(object) {
     var array = [];
     for (let category in object) {
-      for (var i = 0; i < object[category].length - 1; i++) {
-        array.push(object[category][i]);
+      if (Array.isArray(category)) {
+        for (var i = 0; i < object[category].length - 1; i++) {
+          array.push(object[category][i]);
+        }
       }
     }
     return array;

--- a/react-client/src/components/ViewTrips/TripsView/tripslist/Images.jsx
+++ b/react-client/src/components/ViewTrips/TripsView/tripslist/Images.jsx
@@ -9,19 +9,15 @@ class Images extends React.Component {
     super(props);
   }
 
-  buildGrid(object) {
-    var array = [];
-    for (let category in object) {
-      if (Array.isArray(category)) {
-        for (var i = 0; i < object[category].length - 1; i++) {
-          array.push(object[category][i]);
-        }
-      }
-    }
-    return array;
-  }
-
   render() {
+
+    const subtitles = {
+      lodging: 'Hotel',
+      attractions: 'Attraction',
+      food: 'Restaurant'
+    }
+
+    console.log('carosel data on trip: ', this.props.caroselData);
 
     return (
 
@@ -46,17 +42,18 @@ class Images extends React.Component {
         >
           {
             // mock data
-            this.buildGrid(exampleData).map( (tile, i) => (
+            this.props.caroselData.map( (tile, i) => (
               <GridTile
                 key={i}
                 style={{
                   height: '95%'
                 }}
-                title={tile.title}
-                subtitle={tile.author}
+                title={tile.name}
+                titleStyle={{fontSize: '14px'}}
+                subtitle={subtitles[tile.subtitle]}
                 titleBackground="linear-gradient(to top, rgba(0,0,0,0.7) 0%,rgba(0,0,0,0.3) 70%,rgba(0,0,0,0) 100%)"
               >
-                <img src={tile.img} />
+                <img src={tile.image_url} />
               </GridTile>
             ))
           }

--- a/react-client/src/components/ViewTrips/TripsView/tripslist/Trip.jsx
+++ b/react-client/src/components/ViewTrips/TripsView/tripslist/Trip.jsx
@@ -11,6 +11,8 @@ class Trip extends React.Component {
 
   render() {
 
+    console.log('Trip created: ', this.props.trip);
+
     return (
 
       <div style={{

--- a/react-client/src/components/ViewTrips/TripsView/tripslist/Trip.jsx
+++ b/react-client/src/components/ViewTrips/TripsView/tripslist/Trip.jsx
@@ -9,6 +9,19 @@ class Trip extends React.Component {
     super(props);
   }
 
+  buildGridData(object) {
+    var array = [];
+    for (let category in object) {
+      if (Array.isArray(object[category])) {
+        for (var i = 0; i < object[category].length; i++) {
+          object[category][i].subtitle = category
+          array.push(object[category][i]);
+        }
+      }
+    }
+    return array;
+  }
+
   render() {
 
     console.log('Trip created: ', this.props.trip);
@@ -50,8 +63,8 @@ class Trip extends React.Component {
               alignItems: 'center',
               backgroundColor: '#d9d9d9'
             }}>
-              <span style={{paddingLeft: '10px'}}>My Trip</span>
-              <span style={{paddingRight: '10px'}}>Destination</span>
+              <span style={{paddingLeft: '10px'}}>{this.props.trip.name}</span>
+              <span style={{paddingRight: '10px'}}>{this.props.trip.destination}</span>
             </div>
 
             <div id='trip-body-text-body' style={{
@@ -61,7 +74,12 @@ class Trip extends React.Component {
               flexDirection: 'row',
               backgroundColor: '#e6e6e6'
             }}>
-              <span style={{padding: '10px 0 0 10px'}}>Description</span>
+              <span style={{
+                padding: '10px 0 0 10px',
+                fontSize: '12px'
+              }}>
+                {this.props.trip.description}
+              </span>
             </div>
 
             <div id='view-edit-button' style={{
@@ -86,7 +104,7 @@ class Trip extends React.Component {
             display: 'flex',
             backgroundColor: '#f2f2f2'
           }}>
-            <Images />
+            <Images caroselData={this.buildGridData(this.props.trip)}/>
           </div>
 
         </div>

--- a/react-client/src/components/ViewTrips/TripsView/tripslist/TripsList.jsx
+++ b/react-client/src/components/ViewTrips/TripsView/tripslist/TripsList.jsx
@@ -10,6 +10,8 @@ class TripsList extends React.Component {
 
   render() {
 
+    console.log('trips on TripsList: ', this.props.trips);
+
     return (
 
       <div style={{
@@ -21,13 +23,11 @@ class TripsList extends React.Component {
         justifyContent: 'flex-start',
         alignItems: 'center',
       }}>
-        <Trip />
-        <Trip />
-        <Trip />
-        <Trip />
-        <Trip />
-        <Trip />
-        <Trip />
+        {
+          this.props.trips.map( (trip, i) => {
+            return <Trip key={i} trip={trip}/>
+          }) 
+        }
       </div>
 
     )

--- a/react-client/src/components/ViewTrips/TripsView/tripslist/exampleData.js
+++ b/react-client/src/components/ViewTrips/TripsView/tripslist/exampleData.js
@@ -1,0 +1,53 @@
+module.exports={
+  attractions: [
+    {
+      img: 'http://i2.cdn.cnn.com/cnnnext/dam/assets/161201115958-68-year-in-pictures-2016-restricted-super-169.jpg',
+      title: 'Breakfast',
+      author: 'attractions',
+    },
+    {
+      img: 'http://i2.cdn.cnn.com/cnnnext/dam/assets/161201161116-83-year-in-pictures-2016-restricted-super-169.jpg',
+      title: 'Tasty burger',
+      author: 'attractions',
+    },
+    {
+      img: 'https://i.ytimg.com/vi/qh7LLydY8eo/maxresdefault.jpg',
+      title: 'Camera',
+      author: 'attractions',
+    }
+  ],
+  hotels: [
+    {
+      img: 'http://i2.cdn.cnn.com/cnnnext/dam/assets/161201115958-68-year-in-pictures-2016-restricted-super-169.jpg',
+      title: 'Breakfast',
+      author: 'hotels',
+    },
+    {
+      img: 'http://i2.cdn.cnn.com/cnnnext/dam/assets/161201161116-83-year-in-pictures-2016-restricted-super-169.jpg',
+      title: 'Tasty burger',
+      author: 'hotels',
+    },
+    {
+      img: 'https://i.ytimg.com/vi/qh7LLydY8eo/maxresdefault.jpg',
+      title: 'Camera',
+      author: 'hotels',
+    }
+  ],
+  restaurants: [
+    {
+      img: 'http://i2.cdn.cnn.com/cnnnext/dam/assets/161201115958-68-year-in-pictures-2016-restricted-super-169.jpg',
+      title: 'Breakfast',
+      author: 'restaurants',
+    },
+    {
+      img: 'http://i2.cdn.cnn.com/cnnnext/dam/assets/161201161116-83-year-in-pictures-2016-restricted-super-169.jpg',
+      title: 'Tasty burger',
+      author: 'restaurants',
+    },
+    {
+      img: 'https://i.ytimg.com/vi/qh7LLydY8eo/maxresdefault.jpg',
+      title: 'Camera',
+      author: 'restaurants',
+    }
+  ]
+};

--- a/react-client/src/index.jsx
+++ b/react-client/src/index.jsx
@@ -23,9 +23,19 @@ class App extends React.Component {
     };
     this.logIn = this.logIn.bind(this);
     this.changePage = this.changePage.bind(this);
+    this.createToView = this.createToView.bind(this);
     this.handleDrawerToggle = this.handleDrawerToggle.bind(this);
     this.handleDrawerClose = this.handleDrawerClose.bind(this);
     this.setDrawerState = this.setDrawerState.bind(this);
+  }
+
+  createToView(trips, page) {
+    console.log('trips being sent: ', trips);
+    console.log('page being redirected: ', page);
+    this.setState({
+      trips: trips,
+      page: page
+    });
   }
 
   changePage(page) {
@@ -47,6 +57,7 @@ class App extends React.Component {
       contentType: 'application/json',
       dataType: 'json'
     }).then((data) => {
+      console.log('data from login: ', data.trips);
       this.setState({
         user,
         trips: data.trips
@@ -116,7 +127,7 @@ class App extends React.Component {
         return <Landing changePage={this.changePage} />
       case pages.CREATE:
         return <CreateView 
-          changePage={this.changePage}
+          createToView={this.createToView}
           handleDrawerToggle={this.handleDrawerToggle}
           handleDrawerClose={this.handleDrawerClose}
           drawerIsOpen={this.state.drawerIsOpen}

--- a/server/index.js
+++ b/server/index.js
@@ -44,6 +44,8 @@ app.post('/save', (req, res) => {
   newTrip.attractions = data.attractions;
   newTrip.lodging = data.lodging;
   newTrip.destination = data.destination;
+  newTrip.name = data.name;
+  newTrip.description = data.description;
   newTrip.save(err => {
   if (err) {
     throw err;
@@ -55,13 +57,12 @@ app.post('/save', (req, res) => {
     .then((user) => {
       return user.addTripId(tripId);
     }).then((user) => {
-      var tripArray = user.trips;
-      return Trip.getTrips(tripArray);
-    }).then((result) => {
-      res.send(result);
-    })
-  })
-})
+      Trip.getTrips(user, (fullUser) => {
+        res.status(200).send(fullUser);
+      });
+    });
+  });
+});
 
 
 
@@ -90,7 +91,9 @@ app.get('/getAll', (req, res) => {
 app.post('/logIn', (req, res) => {
   User.findOrCreate(req.body)
     .then((user) => {
-      res.json(user);
+      Trip.getTrips(user, (fullUser) => {
+        res.json(fullUser);
+      });
     })
     .catch((err) => {
       console.log(err);


### PR DESCRIPTION
- On login, the full user trips data is returned instead of trip ID's

-On successful trip save in CreateView, the user information in the database is updated with id, and full trips are returned.  After data arrives, the state on the root of the app (page, trips) is updated, re-rendering the main component view on the page to the list and with the trip data.

All of this involved slight refactors to the 'getTrips' function in database-mongo/trips.js.  I had to implement a callback to make sure I could get both the user data and the trips data that I wanted back.  This allows both the login endpoint and the save endpoint to access the same function.

